### PR TITLE
mvp arch basics

### DIFF
--- a/android_java_hummus/src/main/java/com/github/klee0kai/hummus/arch/mvp/IRefreshView.java
+++ b/android_java_hummus/src/main/java/com/github/klee0kai/hummus/arch/mvp/IRefreshView.java
@@ -1,0 +1,10 @@
+package com.github.klee0kai.hummus.arch.mvp;
+
+public interface IRefreshView {
+
+    /**
+     * Refresh UI view with new data
+     */
+    void refreshUI();
+
+}

--- a/android_java_hummus/src/main/java/com/github/klee0kai/hummus/arch/mvp/ISimplePresenter.java
+++ b/android_java_hummus/src/main/java/com/github/klee0kai/hummus/arch/mvp/ISimplePresenter.java
@@ -1,0 +1,22 @@
+package com.github.klee0kai.hummus.arch.mvp;
+
+public interface ISimplePresenter {
+
+    /**
+     * get view state by key
+     */
+    Object getState(String stateId);
+
+    /**
+     * safe view state by key
+     */
+    void saveState(String stateId, Object state);
+
+    /**
+     * subscribe view for data update
+     */
+    void subscribe(IRefreshView view);
+
+    void unsubscribe(IRefreshView view);
+
+}

--- a/android_java_hummus/src/main/java/com/github/klee0kai/hummus/arch/mvp/SimplePresenter.java
+++ b/android_java_hummus/src/main/java/com/github/klee0kai/hummus/arch/mvp/SimplePresenter.java
@@ -1,0 +1,31 @@
+package com.github.klee0kai.hummus.arch.mvp;
+
+import java.util.WeakHashMap;
+
+public class SimplePresenter implements ISimplePresenter {
+
+    protected final WeakViewsList views = new WeakViewsList();
+    protected final WeakHashMap<String, Object> viewsStates = new WeakHashMap<>();
+
+    @Override
+    public Object getState(String stateId) {
+        return viewsStates.get(stateId);
+    }
+
+    @Override
+    public void saveState(String stateId, Object state) {
+        viewsStates.put(stateId, state);
+    }
+
+
+    @Override
+    public void subscribe(IRefreshView view) {
+        views.add(view);
+    }
+
+    @Override
+    public void unsubscribe(IRefreshView view) {
+        views.remove(view);
+    }
+
+}

--- a/android_java_hummus/src/main/java/com/github/klee0kai/hummus/arch/mvp/WeakViewsList.java
+++ b/android_java_hummus/src/main/java/com/github/klee0kai/hummus/arch/mvp/WeakViewsList.java
@@ -1,0 +1,22 @@
+package com.github.klee0kai.hummus.arch.mvp;
+
+import com.github.klee0kai.hummus.collections.weaklist.WeakList;
+import com.github.klee0kai.hummus.threads.AndroidThreads;
+
+public class WeakViewsList extends WeakList<IRefreshView> {
+
+    public void refreshAllViews() {
+        AndroidThreads.runMain(() -> {
+            for (IRefreshView v : this)
+                v.refreshUI();
+        });
+    }
+
+    public void refreshAllViews(int delay) {
+        AndroidThreads.runMainDelayed(delay, () -> {
+            for (IRefreshView v : this)
+                v.refreshUI();
+        });
+    }
+
+}


### PR DESCRIPTION
MVP arch basics: 
 - view layer have only one method for refresh UI 
 - all UI states save and restored from presenter. 
 - Presenter and View working over weak subscriber pattern